### PR TITLE
Add RSS feed for blog posts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 import "./globals.css"
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -17,9 +18,15 @@ const codeFont = JetBrains_Mono({
   variable: '--font-mono'
 })
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Phillip Carter",
   description: "Phillip Carter's spot on the web.",
+  metadataBase: new URL("https://phillipcarter.dev"),
+  alternates: {
+    types: {
+      "application/rss+xml": "/rss.xml",
+    },
+  },
 }
 
 interface RootLayoutProps {

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -29,7 +29,8 @@ function buildRssItem({
 
 export async function GET() {
   const items = allPosts
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .map(post => ({ ...post, _timestamp: new Date(post.date).getTime() }))
+    .sort((a, b) => b._timestamp - a._timestamp)
     .map((post) =>
       buildRssItem({
         title: post.title,

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -48,7 +48,15 @@ export async function GET() {
       <link>${SITE_URL}</link>
       <description><![CDATA[Phillip Carter's spot on the web.]]></description>
       <language>en-us</language>
-      <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+      <lastBuildDate>${
+        allPosts.length > 0
+          ? new Date(
+              allPosts
+                .map((post) => post.date)
+                .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0]
+            ).toUTCString()
+          : new Date().toUTCString()
+      }</lastBuildDate>
       ${items}
     </channel>
   </rss>`

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,61 @@
+import { allPosts } from "contentlayer/generated"
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://phillipcarter.dev"
+
+function buildRssItem({
+  title,
+  description,
+  slug,
+  date,
+}: {
+  title: string
+  description?: string
+  slug: string
+  date: string
+}) {
+  const postUrl = `${SITE_URL}${slug}`
+
+  return `
+    <item>
+      <title><![CDATA[${title}]]></title>
+      ${description ? `<description><![CDATA[${description}]]></description>` : ""}
+      <link>${postUrl}</link>
+      <guid isPermaLink="true">${postUrl}</guid>
+      <pubDate>${new Date(date).toUTCString()}</pubDate>
+    </item>
+  `
+}
+
+export async function GET() {
+  const items = allPosts
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .map((post) =>
+      buildRssItem({
+        title: post.title,
+        description: post.description,
+        slug: post.slug,
+        date: post.date,
+      }),
+    )
+    .join("")
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0">
+    <channel>
+      <title><![CDATA[Phillip Carter]]></title>
+      <link>${SITE_URL}</link>
+      <description><![CDATA[Phillip Carter's spot on the web.]]></description>
+      <language>en-us</language>
+      <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+      ${items}
+    </channel>
+  </rss>`
+
+  return new Response(feed, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add an RSS feed route that serializes blog posts with absolute URLs
- allow overriding the site URL while defaulting to phillipcarter.dev
- surface the feed through the app metadata alternates

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69405b2e8d808332a59acba652cc93b0)