### PR TITLE
Tighten layout padding and refine sidebar/home/tag UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ import { Inter, JetBrains_Mono } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Analytics } from "@/components/analytics"
 import { ModeToggle } from "@/components/mode-toggle"
+import { ScrollToTop } from "@/components/ScrollToTop"
+import { SidebarAboutPanel } from "@/components/SidebarAboutPanel"
 import {
   siBluesky as BlueskyIcon,
   siGithub as GithubIcon,
@@ -31,22 +33,6 @@ export const metadata: Metadata = {
 
 interface RootLayoutProps {
   children: React.ReactNode
-}
-
-function NavLinks() {
-  return (
-    <nav className="ml-auto text-sm font-medium flex items-center space-x-2">
-      <Link
-        href="/about"
-        className="p-2 rounded-lg text-gray-600 dark:text-gray-400
-                   hover:bg-purple-50 dark:hover:bg-purple-900/10
-                   hover:text-purple-700 dark:hover:text-purple-300
-                   transition-colors duration-200"
-      >
-        About
-      </Link>
-    </nav>
-  );
 }
 
 function SocialLinks() {
@@ -112,32 +98,66 @@ export default function RootLayout({ children }: RootLayoutProps) {
         `}} />
       </head>
       <body
-        className={`antialiased min-h-screen bg-slate-100 dark:bg-slate-900 text-slate-900 dark:text-slate-50 ${inter.className} ${codeFont.variable}`}
+        className={`antialiased min-h-screen text-slate-900 dark:text-slate-50 ${inter.className} ${codeFont.variable}`}
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <div className="max-w-4xl mx-auto py-10 px-4">
-            <div className="rounded-lg bg-white dark:bg-slate-950 shadow-sm">
-              <div className="p-8">
-                <header className="pb-2 border-b border-gray-200 dark:border-gray-800">
-                  <div className="flex items-center justify-between">
-                    <Link
-                      href="/"
-                      className="group font-mono text-2xl font-bold tracking-tight text-gray-600 dark:text-gray-400 hover:bg-purple-50 dark:hover:bg-purple-900/10
-                      hover:text-purple-700 dark:hover:text-purple-300
-                      transition-colors duration-200
-                      p-2 rounded-lg"
-                    >
-                      PC{">"}
-                      <span className="ml-2 animate-cursor-blink group-hover:animate-cursor-spin inline-block">_</span>
-                    </Link>
-                    <NavLinks />
-                    <div className="mx-4 w-px h-6 bg-gray-200 dark:bg-gray-700" />
-                    <SocialLinks />
-                    <div className="mx-4 w-px h-6 bg-gray-200 dark:bg-gray-700" />
-                    <ModeToggle />
+          <ScrollToTop />
+          <div className="relative isolate min-h-screen overflow-hidden lg:overflow-visible bg-slate-100 dark:bg-slate-950 selection:bg-lime-200 selection:text-slate-900 dark:selection:bg-emerald-400/30">
+            <div className="pointer-events-none absolute inset-0">
+              <div className="absolute inset-0 opacity-65 mix-blend-soft-light bg-[radial-gradient(circle_at_20%_20%,rgba(99,102,241,0.18),transparent_42%),radial-gradient(circle_at_82%_12%,rgba(16,185,129,0.18),transparent_34%),radial-gradient(circle_at_60%_82%,rgba(14,165,233,0.16),transparent_36%)]" />
+              <div className="absolute inset-0 opacity-60 bg-[linear-gradient(rgba(148,163,184,0.16)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.16)_1px,transparent_1px)] bg-[size:160px_160px]" />
+              <div className="absolute inset-0 mix-blend-overlay bg-[radial-gradient(120%_60%_at_50%_-10%,rgba(255,255,255,0.65),transparent)] dark:bg-[radial-gradient(120%_60%_at_50%_-10%,rgba(255,255,255,0.08),transparent)]" />
+            </div>
+            <div className="relative max-w-6xl mx-auto px-5 sm:px-6 py-10 lg:py-12">
+              <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+                <aside className="h-fit lg:sticky lg:top-10 rounded-3xl border border-slate-200/80 dark:border-slate-800/80 bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl shadow-[0_20px_90px_rgba(15,23,42,0.25)] p-5 lg:p-6 space-y-6">
+                  <Link
+                    href="/"
+                    className="group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-slate-50/70 dark:bg-slate-900/70 px-4 py-3 hover:border-sky-400 dark:hover:border-sky-500 transition-colors"
+                  >
+                    <span className="relative flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-sky-200 via-emerald-200 to-purple-200 dark:from-sky-500/20 dark:via-emerald-500/20 dark:to-purple-500/20 text-lg font-bold text-slate-900 dark:text-slate-50 shadow-inner shadow-white/40 dark:shadow-white/5">
+                      PC
+                      <span className="absolute inset-0 rounded-2xl border border-white/50 dark:border-white/10" />
+                    </span>
+                    <div className="flex flex-col gap-1">
+                      <span className="font-mono text-sm text-slate-500 dark:text-slate-400">/blog</span>
+                      <span className="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+                        Phillip Carter
+                      </span>
+                    </div>
+                  </Link>
+
+                  <SidebarAboutPanel className="space-y-4 rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-slate-50/70 dark:bg-slate-900/70 px-4 py-4">
+                    <div className="text-[11px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">About</div>
+                    <div className="space-y-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                      <p>In my day job, I’m a PM Director at Salesforce working on their Automations platform. I used to work at Honeycomb, where I led AI efforts. Prior to this, I worked on Honeycomb&apos;s telemetry pipeline, OpenTelemetry efforts, and API. I also worked on the .NET team at Microsoft for several years, including 5 years as the PM for the F# programming language and tools.</p>
+                      <p>I’m also a maintainer in the OpenTelemetry project, primarily focusing on the website. I do occasionally send PRs to other parts of the project, though. I will occasionally release updates to some packages I still maintain.</p>
+                    </div>
+                  </SidebarAboutPanel>
+
+                  <div className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200/80 dark:border-slate-800/80 bg-slate-50/70 dark:bg-slate-900/70 px-4 py-2.5">
+                    <div className="flex items-center gap-2 text-xs font-mono text-slate-500 dark:text-slate-400">
+                      <span className="h-3 w-3 rounded-sm bg-slate-300 dark:bg-slate-700" />
+                      <span>links</span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <SocialLinks />
+                      <ModeToggle />
+                    </div>
                   </div>
-                </header>
-                <main className="mt-8">{children}</main>
+                </aside>
+
+                <div className="space-y-6">
+                  <div className="rounded-[28px] border border-slate-200/80 dark:border-slate-800/80 bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl shadow-[0_20px_90px_rgba(15,23,42,0.25)]">
+                    <div className="relative overflow-hidden rounded-[28px] border border-slate-100/80 dark:border-slate-800/80">
+                      <div className="absolute -inset-x-10 -top-10 h-40 bg-gradient-to-br from-sky-200/50 via-transparent to-purple-200/40 dark:from-sky-500/15 dark:via-transparent dark:to-purple-500/15 blur-3xl" />
+                      <div className="absolute inset-0 border border-white/60 dark:border-white/5 rounded-[28px] pointer-events-none" />
+                      <div className="relative p-6 sm:p-8 lg:p-10">
+                        <main>{children}</main>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,36 +8,64 @@ export default function Home() {
   })
   
   return (
-    <ul className="space-y-6">
-      {allPosts.map((post) => (
-        <li key={post._id} className="group">
-          <div className="space-y-2">
-            <Link href={post.slug} className="block -mx-2 p-2 rounded">
-              <div className="flex items-baseline justify-between gap-4">
-                <span className="text-purple-700 dark:text-purple-300 text-lg">❯</span>
-                <span className="flex-1 font-medium text-lg text-gray-600 dark:text-gray-400
-                                hover:text-purple-700 dark:hover:text-purple-300 
-                                transition-colors">
-                  {post.title}
-                </span>
-                <time className="text-lg text-gray-500 dark:text-gray-400">
-                  {new Date(post.date).toLocaleDateString()}
-                </time>
+    <div className="space-y-8">
+      <div className="flex items-center gap-3 text-xs uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+        <span className="h-px flex-1 bg-slate-200 dark:bg-slate-800" />
+        <span className="px-3 py-1 rounded-full border border-slate-200/80 dark:border-slate-800/80 bg-white/60 dark:bg-slate-900/60">
+          Log
+        </span>
+        <span className="h-px flex-1 bg-slate-200 dark:bg-slate-800" />
+      </div>
+      <ul className="grid gap-5">
+        {allPosts.map((post, index) => (
+          <li key={post._id} className="group relative">
+            <Link
+              href={post.slug}
+              className="block overflow-hidden rounded-2xl border border-slate-200/80 dark:border-slate-800/80
+                         bg-white/70 dark:bg-slate-900/70 backdrop-blur-md transition
+                         hover:-translate-y-1 hover:shadow-[0_30px_120px_rgba(15,23,42,0.25)]
+                         duration-300"
+            >
+              <div className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-emerald-400 via-sky-400 to-purple-500" />
+              <div className="relative grid gap-6 md:grid-cols-[1fr_auto] p-6 lg:p-8">
+                <div className="space-y-4">
+                  <div className="flex items-center gap-3 text-xs font-mono uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+                    <span className="rounded-full border border-slate-200/80 dark:border-slate-800/70 px-3 py-1 bg-white/70 dark:bg-slate-900/70">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="h-px flex-1 bg-slate-200 dark:bg-slate-800" />
+                    <span>Entry</span>
+                  </div>
+                  <div className="space-y-3">
+                    <h2 className="text-2xl sm:text-3xl font-semibold leading-tight text-slate-900 dark:text-slate-50">
+                      {post.title}
+                    </h2>
+                    {post.description && (
+                      <p className="text-sm text-slate-600 dark:text-slate-400 max-w-2xl">
+                        {post.description}
+                      </p>
+                    )}
+                    {post.tags && (
+                      <TagList tags={post.tags} />
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end justify-between gap-4 text-right">
+                  <time className="rounded-full border border-slate-300/80 dark:border-slate-700/80 px-4 py-2 text-xs uppercase tracking-[0.18em] text-slate-600 dark:text-slate-300 bg-slate-50/70 dark:bg-slate-900/60">
+                    {new Date(post.date).toLocaleDateString()}
+                  </time>
+                  <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
+                    <span className="h-8 w-px bg-slate-200 dark:bg-slate-800" />
+                    <span className="text-lg text-sky-500 dark:text-sky-300 transition-transform duration-300 group-hover:translate-x-1.5">
+                      ↗
+                    </span>
+                  </div>
+                </div>
               </div>
             </Link>
-            {post.description && (
-              <p className="text-sm text-gray-600 dark:text-gray-400 ml-6">
-                {post.description}
-              </p>
-            )}
-            {post.tags && (
-              <div className="ml-6">
-                <TagList tags={post.tags} />
-              </div>
-            )}
-          </div>
-        </li>
-      ))}
-    </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/components/ScrollToTop.tsx
+++ b/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+export function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname]);
+
+  return null;
+}

--- a/components/SidebarAboutPanel.tsx
+++ b/components/SidebarAboutPanel.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+interface SidebarAboutPanelProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function SidebarAboutPanel({ className = "", children }: SidebarAboutPanelProps) {
+  const pathname = usePathname();
+  const isPostPage = pathname?.startsWith("/posts/") ?? false;
+  const visibility = isPostPage ? "hidden lg:block" : "";
+
+  return <div className={`${visibility} ${className}`.trim()}>{children}</div>;
+}

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -9,9 +9,10 @@ export function TagList({ tags }: { tags: string }) {
         <Link
           key={tag}
           href={`/tags/${encodeURIComponent(tag)}`}
-          className="text-sm px-3 py-1 bg-purple-100 dark:bg-purple-900/30 
-                     text-purple-700 dark:text-purple-300 rounded-full 
-                     hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
+          className="text-xs px-3 py-1 rounded-full border border-slate-300/80 dark:border-slate-700/80
+                     bg-white/70 dark:bg-slate-900/60 text-slate-700 dark:text-slate-200
+                     tracking-[0.1em] uppercase hover:border-sky-400 dark:hover:border-sky-500
+                     transition-colors"
         >
           {tag}
         </Link>


### PR DESCRIPTION
### Motivation
- Reduce excessive outer and inner padding so the layout feels tighter but still breathable.  
- Keep the About sidebar visible on larger screens but hide it on mobile post pages to reduce clutter.  
- Refresh the home listing into a card-style grid for clearer visual hierarchy.  
- Update tag visuals to match the tighter spacing and updated design language.

### Description
- Tightened spacing and radii in `app/layout.tsx`, adjusted container paddings and component paddings, and replaced the old header layout with the updated layout grid.  
- Added `components/ScrollToTop.tsx` to reset scroll on route changes and `components/SidebarAboutPanel.tsx` as a path-aware client component that hides the panel on `/posts/*`.  
- Reworked `app/page.tsx` to render posts as a card-style grid with upgraded metadata and hover interactions.  
- Updated `components/TagList.tsx` to new compact, bordered, uppercase tag styling to match the refreshed layout.

### Testing
- Started the dev server with `pnpm dev`, the app compiled and Contentlayer generated documents successfully.  
- A Playwright script was run to capture a homepage screenshot and produced `artifacts/home.png` successfully.  
- Google Fonts failed to download in the environment but the build fell back to system fonts and compilation completed.  
- No lint step was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7267b75083329331eef04cd79c2f)