### PR TITLE
Remove blog card arrow icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,9 +56,6 @@ export default function Home() {
                   </time>
                   <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
                     <span className="h-8 w-px bg-slate-200 dark:bg-slate-800" />
-                    <span className="text-lg text-sky-500 dark:text-sky-300 transition-transform duration-300 group-hover:translate-x-1.5">
-                      ↗
-                    </span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- The blog post cards on the home page should no longer display the arrow affordance next to the date.
- Simplify the card visual by removing the decorative arrow and its hover animation.

### Description
- Removed the arrow element and its hover translate classes from the blog card in `app/page.tsx`.
- Updated the card markup to leave only the date and separator in the right-aligned column.
- The change is contained to a single file: `app/page.tsx`.
- The change was committed with the message `Remove blog card arrow icon`.

### Testing
- Started the dev server with `pnpm exec next dev` which launched the Next.js dev server (succeeded).
- Ran a Playwright script to capture the home page screenshot which produced `artifacts/home-no-arrow.png` (succeeded).
- Next.js compilation logged a module resolution error for `@/.contentlayer/generated` causing a 404 on `/` (failed during build).
- No unit tests were executed as part of this change (`pnpm test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eefbeba508332bcc3bf914edda0b1)