### PR TITLE
Add LinkedIn profile link to sidebar social links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,6 +78,26 @@ function SocialLinks() {
           <path d={GithubIcon.path} />
         </svg>
       </a>
+      <a
+        href="https://www.linkedin.com/in/phillip-carter-4714a135"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="p-2 rounded-lg
+                   hover:bg-purple-50 dark:hover:bg-purple-900/10
+                   transition-colors duration-200"
+        aria-label="LinkedIn Profile"
+      >
+        <svg
+          width={16}
+          height={16}
+          viewBox="0 0 448 512"
+          className="fill-gray-600 dark:fill-gray-400
+                     hover:fill-purple-700 dark:hover:fill-purple-300
+                     transition-colors duration-200"
+        >
+          <path d="M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3zM447.9 448h-92.68V302.4c0-34.7-.7-79.2-48.29-79.2-48.29 0-55.69 37.7-55.69 76.7V448h-92.78V148.9h89.08v40.8h1.3c12.4-23.5 42.69-48.3 87.88-48.3 94 0 111.28 61.9 111.28 142.3V448z" />
+        </svg>
+      </a>
     </>
   );
 }


### PR DESCRIPTION
### Motivation

- Add a LinkedIn profile link to the site's sidebar social links so visitors can find the author on LinkedIn. 
- Keep the link visually consistent with existing social icons for Bluesky and GitHub. 
- Avoid runtime errors from a missing `siLinkedin` export in the installed `simple-icons` package. 

### Description

- Added a LinkedIn anchor element with `href="https://www.linkedin.com/in/phillip-carter-4714a135"` to `app/layout.tsx` alongside existing social links. 
- Rendered a LinkedIn SVG icon inline using a `viewBox` of `"0 0 448 512"` and the LinkedIn `path` data to avoid importing a non-exported icon. 
- Removed the attempt to import `siLinkedin` from `simple-icons` to prevent an import-time error. 

### Testing

- Ran the dev server with `npm run dev`, which initially failed due to the missing `siLinkedin` export and was resolved after switching to an inline SVG. 
- After the inline SVG change, the dev server started and Contentlayer generated documents successfully. 
- Attempted a Playwright-based screenshot to validate the UI, but the Chromium launch crashed in the environment and the screenshot step failed. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef892226c8332b1a18bdbc013640c)