### PR TITLE
Move blog date bubble into header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,14 +27,16 @@ export default function Home() {
                          duration-300"
             >
               <div className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-emerald-400 via-sky-400 to-purple-500" />
-              <div className="relative grid gap-6 md:grid-cols-[1fr_auto] p-6 lg:p-8">
+              <div className="relative grid gap-6 p-6 lg:p-8">
                 <div className="space-y-4">
                   <div className="flex items-center gap-3 text-xs font-mono uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
                     <span className="rounded-full border border-slate-200/80 dark:border-slate-800/70 px-3 py-1 bg-white/70 dark:bg-slate-900/70">
                       {String(index + 1).padStart(2, "0")}
                     </span>
                     <span className="h-px flex-1 bg-slate-200 dark:bg-slate-800" />
-                    <span>Entry</span>
+                    <time className="rounded-full border border-slate-300/80 dark:border-slate-700/80 px-3 py-1 text-xs uppercase tracking-[0.18em] text-slate-600 dark:text-slate-300 bg-slate-50/70 dark:bg-slate-900/60">
+                      {new Date(post.date).toLocaleDateString()}
+                    </time>
                   </div>
                   <div className="space-y-3">
                     <h2 className="text-2xl sm:text-3xl font-semibold leading-tight text-slate-900 dark:text-slate-50">
@@ -48,14 +50,6 @@ export default function Home() {
                     {post.tags && (
                       <TagList tags={post.tags} />
                     )}
-                  </div>
-                </div>
-                <div className="flex flex-col items-end justify-between gap-4 text-right">
-                  <time className="rounded-full border border-slate-300/80 dark:border-slate-700/80 px-4 py-2 text-xs uppercase tracking-[0.18em] text-slate-600 dark:text-slate-300 bg-slate-50/70 dark:bg-slate-900/60">
-                    {new Date(post.date).toLocaleDateString()}
-                  </time>
-                  <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400">
-                    <span className="h-8 w-px bg-slate-200 dark:bg-slate-800" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Replace the literal "Entry" label in blog cards with the post date to make the header more informative.
- Remove the duplicated date badge that appeared below the post title to reduce visual redundancy.

### Description
- Updated `app/page.tsx` to remove the `md:grid-cols-[1fr_auto]` layout and simplify the grid to a single-column layout on the card container.
- Replaced the header `span` that displayed "Entry" with a `time` element that renders `new Date(post.date).toLocaleDateString()` as the date bubble.
- Removed the secondary `time` element and adjacent spacer that previously appeared to the right/below the title, cleaning up markup.
- Adjusted related classnames to preserve styling for the new date bubble in the header.

### Testing
- Launched the dev server with `npm run dev`, which compiled the app and served the home page (Next compiled and returned `GET / 200`).
- Captured a visual verification screenshot using a Playwright script saved to `artifacts/blog-cards-date-bubble.png`, and the script completed successfully.
- Observed Google Fonts fetch warnings during dev runtime, but the Next app fell back to system fonts and continued serving pages successfully.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e621cd948332b6c0f3cf845f13b8)