### PR TITLE
Celebrate puzzle completion — add solved animation and play-again UI

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link"
+
+const games = [
+  {
+    title: "Shape Circuit",
+    description: "Rotate shapes and cycle colors until your board matches the target pattern.",
+    href: "/games/shape-puzzle",
+    detail: "Medium difficulty · 3×3 grid",
+  },
+]
+
+export const metadata = {
+  title: "Games",
+  description: "Playable mini-games and puzzles.",
+}
+
+export default function GamesPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <p className="text-xs font-mono uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Games</p>
+        <div className="space-y-2">
+          <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 dark:text-slate-50">Playable puzzles</h1>
+          <p className="text-sm sm:text-base text-slate-600 dark:text-slate-300 max-w-2xl">
+            Short-form experiments built around visuals and mechanics. Pick a game to play directly in the browser.
+          </p>
+        </div>
+      </header>
+
+      <ul className="grid gap-5">
+        {games.map((game) => (
+          <li key={game.title} className="group relative">
+            <Link
+              href={game.href}
+              className="block overflow-hidden rounded-2xl border border-slate-200/80 dark:border-slate-800/80
+                         bg-white/70 dark:bg-slate-900/70 backdrop-blur-md transition
+                         hover:-translate-y-1 hover:shadow-[0_30px_120px_rgba(15,23,42,0.25)]
+                         duration-300"
+            >
+              <div className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-emerald-400 via-sky-400 to-purple-500" />
+              <div className="relative grid gap-4 p-6 lg:p-8">
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center gap-3 text-xs font-mono uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+                    <span className="rounded-full border border-slate-200/80 dark:border-slate-800/70 px-3 py-1 bg-white/70 dark:bg-slate-900/70">
+                      {game.detail}
+                    </span>
+                    <span className="h-px flex-1 bg-slate-200 dark:bg-slate-800" />
+                  </div>
+                  <div className="space-y-2">
+                    <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">{game.title}</h2>
+                    <p className="text-sm text-slate-600 dark:text-slate-400 max-w-2xl">
+                      {game.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/games/shape-puzzle/ShapePuzzleGame.tsx
+++ b/app/games/shape-puzzle/ShapePuzzleGame.tsx
@@ -1,0 +1,276 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import type { MouseEvent } from "react"
+
+type ShapeId = "circle" | "square" | "triangle" | "diamond"
+
+type ColorId = "coral" | "sky" | "lime" | "violet"
+
+type Cell = {
+  shape: ShapeId
+  color: ColorId
+}
+
+const shapes: { id: ShapeId; label: string }[] = [
+  { id: "circle", label: "Circle" },
+  { id: "square", label: "Square" },
+  { id: "triangle", label: "Triangle" },
+  { id: "diamond", label: "Diamond" },
+]
+
+const colors: { id: ColorId; label: string; hex: string }[] = [
+  { id: "coral", label: "Coral", hex: "#fb7185" },
+  { id: "sky", label: "Sky", hex: "#38bdf8" },
+  { id: "lime", label: "Lime", hex: "#84cc16" },
+  { id: "violet", label: "Violet", hex: "#a855f7" },
+]
+
+const targetBoard: Cell[] = [
+  { shape: "circle", color: "coral" },
+  { shape: "square", color: "sky" },
+  { shape: "triangle", color: "lime" },
+  { shape: "diamond", color: "violet" },
+  { shape: "square", color: "coral" },
+  { shape: "triangle", color: "sky" },
+  { shape: "diamond", color: "lime" },
+  { shape: "circle", color: "violet" },
+  { shape: "triangle", color: "coral" },
+]
+
+const getShapeIndex = (shape: ShapeId) => shapes.findIndex((item) => item.id === shape)
+const getColorIndex = (color: ColorId) => colors.findIndex((item) => item.id === color)
+
+const makeInitialBoard = () =>
+  targetBoard.map((cell, index) => {
+    const shapeIndex = getShapeIndex(cell.shape)
+    const colorIndex = getColorIndex(cell.color)
+
+    return {
+      shape: shapes[(shapeIndex + 1 + index) % shapes.length].id,
+      color: colors[(colorIndex + 2 + index) % colors.length].id,
+    }
+  })
+
+const renderShape = (shape: ShapeId, colorHex: string) => {
+  switch (shape) {
+    case "circle":
+      return <circle cx="50" cy="50" r="28" fill={colorHex} />
+    case "square":
+      return <rect x="22" y="22" width="56" height="56" rx="8" fill={colorHex} />
+    case "triangle":
+      return <polygon points="50 16 86 84 14 84" fill={colorHex} />
+    case "diamond":
+      return <polygon points="50 12 88 50 50 88 12 50" fill={colorHex} />
+  }
+}
+
+const ShapeTile = ({ cell, isSelected, isTarget }: { cell: Cell; isSelected: boolean; isTarget: boolean }) => {
+  const color = colors.find((item) => item.id === cell.color) ?? colors[0]
+
+  return (
+    <div
+      className={`flex items-center justify-center rounded-2xl border transition shadow-sm ${
+        isTarget
+          ? "border-slate-200/70 dark:border-slate-700/70 bg-white/60 dark:bg-slate-900/60"
+          : "border-slate-300/80 dark:border-slate-700/80 bg-white/80 dark:bg-slate-900/80"
+      } ${isSelected ? "ring-2 ring-sky-400/80" : ""}`}
+    >
+      <svg viewBox="0 0 100 100" className="h-12 w-12">
+        {renderShape(cell.shape, color.hex)}
+      </svg>
+    </div>
+  )
+}
+
+export default function ShapePuzzleGame() {
+  const [board, setBoard] = useState<Cell[]>(() => makeInitialBoard())
+  const [moves, setMoves] = useState(0)
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+
+  const solved = useMemo(
+    () => board.every((cell, index) => cell.shape === targetBoard[index].shape && cell.color === targetBoard[index].color),
+    [board]
+  )
+
+  const updateCell = (index: number, updater: (cell: Cell) => Cell) => {
+    setBoard((prev) => prev.map((cell, cellIndex) => (cellIndex === index ? updater(cell) : cell)))
+    setMoves((prev) => prev + 1)
+  }
+
+  const cycleShape = (index: number) => {
+    updateCell(index, (cell) => {
+      const shapeIndex = getShapeIndex(cell.shape)
+      return { ...cell, shape: shapes[(shapeIndex + 1) % shapes.length].id }
+    })
+  }
+
+  const cycleColor = (index: number) => {
+    updateCell(index, (cell) => {
+      const colorIndex = getColorIndex(cell.color)
+      return { ...cell, color: colors[(colorIndex + 1) % colors.length].id }
+    })
+  }
+
+  const handleTileClick = (index: number, event: MouseEvent<HTMLButtonElement>) => {
+    setSelectedIndex(index)
+    if (event.shiftKey) {
+      cycleColor(index)
+      return
+    }
+
+    cycleShape(index)
+  }
+
+  const handleReset = () => {
+    setBoard(makeInitialBoard())
+    setMoves(0)
+    setSelectedIndex(null)
+  }
+
+  const selectedCell = selectedIndex !== null ? board[selectedIndex] : null
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <p className="text-xs font-mono uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Puzzle</p>
+        <div className="space-y-2">
+          <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 dark:text-slate-50">Shape Circuit</h1>
+          <p className="text-sm sm:text-base text-slate-600 dark:text-slate-300 max-w-2xl">
+            Align every tile with the target pattern. Click a tile to rotate its shape, or hold Shift while clicking to
+            cycle the color. It&apos;s a medium difficulty logic warm-up.
+          </p>
+        </div>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Target</h2>
+              <p className="text-xs text-slate-500 dark:text-slate-400">Match this arrangement.</p>
+            </div>
+            <span className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">3 × 3</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {targetBoard.map((cell, index) => (
+              <ShapeTile key={`target-${index}`} cell={cell} isSelected={false} isTarget />
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Your Board</h2>
+              <p className="text-xs text-slate-500 dark:text-slate-400">Moves: {moves}</p>
+            </div>
+            <div className="flex items-center gap-3">
+              {solved ? (
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="rounded-full border border-emerald-200/80 bg-emerald-50/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-300 hover:border-emerald-300 dark:hover:border-emerald-400 transition"
+                >
+                  Play again
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
+                >
+                  Reset
+                </button>
+              )}
+              {solved && (
+                <span className="rounded-full border border-emerald-200/80 bg-emerald-50/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-300">
+                  Solved
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            {board.map((cell, index) => (
+              <button
+                key={`play-${index}`}
+                type="button"
+                onClick={(event) => handleTileClick(index, event)}
+                className={`focus:outline-none transition ${
+                  solved ? "animate-[pulse_1.6s_ease-in-out_infinite]" : ""
+                }`}
+                aria-pressed={selectedIndex === index}
+                aria-label={`Tile ${index + 1}: ${shapes.find((item) => item.id === cell.shape)?.label}, ${colors.find((item) => item.id === cell.color)?.label}`}
+              >
+                <ShapeTile cell={cell} isSelected={selectedIndex === index} isTarget={false} />
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-slate-50/80 dark:bg-slate-900/60 p-4 space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Selected tile</p>
+            {selectedCell ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                  {shapes.find((item) => item.id === selectedCell.shape)?.label}
+                </span>
+                <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                  {colors.find((item) => item.id === selectedCell.color)?.label}
+                </span>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => selectedIndex !== null && cycleShape(selectedIndex)}
+                    className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
+                  >
+                    Next shape
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectedIndex !== null && cycleColor(selectedIndex)}
+                    className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
+                  >
+                    Next color
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600 dark:text-slate-300">Select a tile to reveal controls.</p>
+            )}
+          </div>
+
+          {solved && (
+            <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/30 dark:bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-200">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="font-semibold">🎉 Circuit aligned! Puzzle complete.</div>
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="rounded-full border border-emerald-200/80 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200 hover:border-emerald-300 dark:hover:border-emerald-400 transition"
+                >
+                  Play again
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <section className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/70 dark:bg-slate-900/70 p-4">
+          <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">How it works</h3>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Every tile has a shape and a color. Cycle them until your board mirrors the target grid exactly.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/70 dark:bg-slate-900/70 p-4">
+          <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Keyboard tip</h3>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Use Shift + click to change a tile&apos;s color without cycling its shape.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/games/shape-puzzle/page.tsx
+++ b/app/games/shape-puzzle/page.tsx
@@ -1,0 +1,10 @@
+import ShapePuzzleGame from "./ShapePuzzleGame"
+
+export const metadata = {
+  title: "Shape Circuit | Games",
+  description: "A medium difficulty shape-matching puzzle game.",
+}
+
+export default function ShapePuzzlePage() {
+  return <ShapePuzzleGame />
+}


### PR DESCRIPTION
### Motivation
- Provide clear, playful feedback when the Shape Circuit puzzle is completed so the player knows they solved it.
- Give a fast way to restart the puzzle by exposing a `Play again` action when solved.  
- Improve the UI affordance for completion with an animated visual treatment and callout.  

### Description
- Swap the `Reset` control for a `Play again` button when `solved` is true and show a `Solved` badge in the controls area.  
- Add a completion callout panel with a celebratory message and `Play again` action in the game details area.  
- Animate playable tiles on completion by conditionally adding `animate-[pulse_1.6s_ease-in-out_infinite]` to the tile buttons when `solved`.  
- Preserve existing gameplay mechanics and state handlers (`handleTileClick`, `cycleShape`, `cycleColor`, and `handleReset`) while wiring the new UI to the `solved` state.

### Testing
- Launched the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the `/games/shape-puzzle` route compiled and returned `GET /games/shape-puzzle 200`.
- Captured a Playwright screenshot artifact of the updated page at `artifacts/shape-circuit-update.png` to verify the new UI and animation appear as expected.
- Noted Google Fonts downloads failed in the environment but fallbacks were used and compilation was not blocked.  
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643dbeb0288332835387f2bae7e913)