### PR TITLE
Redesign shape puzzle as tango-style 8×8 grid

### DIFF
--- a/app/games/shape-puzzle/ShapePuzzleGame.tsx
+++ b/app/games/shape-puzzle/ShapePuzzleGame.tsx
@@ -19,62 +19,49 @@ const shapes: { id: ShapeId; label: string; color: string }[] = [
   { id: "spire", label: "Spire", color: "#f97316" },
 ]
 
-const gridSize = 8
+const gridSize = 6
 const halfRow = gridSize / 2
 
 const solutionGrid: ShapeId[][] = [
-  ["arc", "arc", "spire", "arc", "spire", "spire", "arc", "spire"],
-  ["spire", "spire", "arc", "spire", "arc", "arc", "spire", "arc"],
-  ["arc", "spire", "arc", "arc", "spire", "spire", "arc", "spire"],
-  ["spire", "arc", "spire", "spire", "arc", "arc", "spire", "arc"],
-  ["arc", "arc", "spire", "spire", "arc", "spire", "arc", "spire"],
-  ["spire", "spire", "arc", "arc", "spire", "arc", "spire", "arc"],
-  ["arc", "spire", "spire", "arc", "arc", "spire", "arc", "spire"],
-  ["spire", "arc", "arc", "spire", "spire", "arc", "spire", "arc"],
+  ["arc", "spire", "arc", "spire", "arc", "spire"],
+  ["spire", "arc", "spire", "arc", "spire", "arc"],
+  ["arc", "spire", "arc", "spire", "arc", "spire"],
+  ["spire", "arc", "spire", "arc", "spire", "arc"],
+  ["arc", "spire", "arc", "spire", "arc", "spire"],
+  ["spire", "arc", "spire", "arc", "spire", "arc"],
 ]
 
 const fixedCells = new Set(
   [
     [0, 0],
-    [0, 4],
-    [0, 7],
+    [0, 3],
+    [0, 5],
     [1, 1],
-    [1, 5],
+    [1, 4],
     [2, 2],
-    [2, 6],
+    [2, 5],
     [3, 0],
-    [3, 7],
-    [4, 3],
-    [4, 5],
+    [3, 3],
+    [4, 1],
+    [4, 4],
     [5, 2],
-    [5, 6],
-    [6, 1],
-    [6, 4],
-    [7, 3],
   ].map(([row, col]) => `${row}-${col}`)
 )
 
 const constraintSeeds: Array<{ row: number; col: number; direction: "right" | "down" }> = [
   { row: 0, col: 0, direction: "right" },
   { row: 0, col: 2, direction: "right" },
-  { row: 0, col: 5, direction: "right" },
+  { row: 0, col: 4, direction: "down" },
   { row: 1, col: 1, direction: "down" },
   { row: 1, col: 3, direction: "right" },
-  { row: 1, col: 4, direction: "down" },
   { row: 2, col: 0, direction: "down" },
-  { row: 2, col: 2, direction: "right" },
-  { row: 2, col: 5, direction: "down" },
+  { row: 2, col: 2, direction: "down" },
+  { row: 2, col: 4, direction: "right" },
   { row: 3, col: 1, direction: "right" },
-  { row: 3, col: 4, direction: "right" },
-  { row: 3, col: 6, direction: "down" },
+  { row: 3, col: 3, direction: "down" },
   { row: 4, col: 0, direction: "right" },
-  { row: 4, col: 2, direction: "down" },
-  { row: 4, col: 5, direction: "right" },
-  { row: 5, col: 1, direction: "down" },
-  { row: 5, col: 3, direction: "right" },
-  { row: 6, col: 0, direction: "right" },
-  { row: 6, col: 2, direction: "down" },
-  { row: 6, col: 5, direction: "right" },
+  { row: 4, col: 2, direction: "right" },
+  { row: 4, col: 4, direction: "right" },
 ]
 
 const constraints: Constraint[] = constraintSeeds.map((seed) => {
@@ -282,7 +269,7 @@ export default function ShapePuzzleGame() {
         <div className="space-y-2">
           <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 dark:text-slate-50">Arc &amp; Spire Tango</h1>
           <p className="text-sm sm:text-base text-slate-600 dark:text-slate-300 max-w-2xl">
-            Fill the 8 × 8 grid so each row and column holds four arcs and four spires. No three identical shapes may
+            Fill the 6 × 6 grid so each row and column holds three arcs and three spires. No three identical shapes may
             touch in a row or column. Match the equality and contrast clues to finish the tango.
           </p>
         </div>

--- a/app/games/shape-puzzle/ShapePuzzleGame.tsx
+++ b/app/games/shape-puzzle/ShapePuzzleGame.tsx
@@ -3,166 +3,296 @@
 import { useMemo, useState } from "react"
 import type { MouseEvent } from "react"
 
-type ShapeId = "circle" | "square" | "triangle" | "diamond"
+type ShapeId = "arc" | "spire"
 
-type ColorId = "coral" | "sky" | "lime" | "violet"
+type CellValue = ShapeId | null
 
-type Cell = {
-  shape: ShapeId
-  color: ColorId
+type Constraint = {
+  row: number
+  col: number
+  direction: "right" | "down"
+  relation: "same" | "different"
 }
 
-const shapes: { id: ShapeId; label: string }[] = [
-  { id: "circle", label: "Circle" },
-  { id: "square", label: "Square" },
-  { id: "triangle", label: "Triangle" },
-  { id: "diamond", label: "Diamond" },
+const shapes: { id: ShapeId; label: string; color: string }[] = [
+  { id: "arc", label: "Arc", color: "#14b8a6" },
+  { id: "spire", label: "Spire", color: "#f97316" },
 ]
 
-const colors: { id: ColorId; label: string; hex: string }[] = [
-  { id: "coral", label: "Coral", hex: "#fb7185" },
-  { id: "sky", label: "Sky", hex: "#38bdf8" },
-  { id: "lime", label: "Lime", hex: "#84cc16" },
-  { id: "violet", label: "Violet", hex: "#a855f7" },
+const gridSize = 8
+const halfRow = gridSize / 2
+
+const solutionGrid: ShapeId[][] = [
+  ["arc", "arc", "spire", "arc", "spire", "spire", "arc", "spire"],
+  ["spire", "spire", "arc", "spire", "arc", "arc", "spire", "arc"],
+  ["arc", "spire", "arc", "arc", "spire", "spire", "arc", "spire"],
+  ["spire", "arc", "spire", "spire", "arc", "arc", "spire", "arc"],
+  ["arc", "arc", "spire", "spire", "arc", "spire", "arc", "spire"],
+  ["spire", "spire", "arc", "arc", "spire", "arc", "spire", "arc"],
+  ["arc", "spire", "spire", "arc", "arc", "spire", "arc", "spire"],
+  ["spire", "arc", "arc", "spire", "spire", "arc", "spire", "arc"],
 ]
 
-const targetBoard: Cell[] = [
-  { shape: "circle", color: "coral" },
-  { shape: "square", color: "sky" },
-  { shape: "triangle", color: "lime" },
-  { shape: "diamond", color: "violet" },
-  { shape: "square", color: "coral" },
-  { shape: "triangle", color: "sky" },
-  { shape: "diamond", color: "lime" },
-  { shape: "circle", color: "violet" },
-  { shape: "triangle", color: "coral" },
+const fixedCells = new Set(
+  [
+    [0, 0],
+    [0, 4],
+    [0, 7],
+    [1, 1],
+    [1, 5],
+    [2, 2],
+    [2, 6],
+    [3, 0],
+    [3, 7],
+    [4, 3],
+    [4, 5],
+    [5, 2],
+    [5, 6],
+    [6, 1],
+    [6, 4],
+    [7, 3],
+  ].map(([row, col]) => `${row}-${col}`)
+)
+
+const constraintSeeds: Array<{ row: number; col: number; direction: "right" | "down" }> = [
+  { row: 0, col: 0, direction: "right" },
+  { row: 0, col: 2, direction: "right" },
+  { row: 0, col: 5, direction: "right" },
+  { row: 1, col: 1, direction: "down" },
+  { row: 1, col: 3, direction: "right" },
+  { row: 1, col: 4, direction: "down" },
+  { row: 2, col: 0, direction: "down" },
+  { row: 2, col: 2, direction: "right" },
+  { row: 2, col: 5, direction: "down" },
+  { row: 3, col: 1, direction: "right" },
+  { row: 3, col: 4, direction: "right" },
+  { row: 3, col: 6, direction: "down" },
+  { row: 4, col: 0, direction: "right" },
+  { row: 4, col: 2, direction: "down" },
+  { row: 4, col: 5, direction: "right" },
+  { row: 5, col: 1, direction: "down" },
+  { row: 5, col: 3, direction: "right" },
+  { row: 6, col: 0, direction: "right" },
+  { row: 6, col: 2, direction: "down" },
+  { row: 6, col: 5, direction: "right" },
 ]
 
-const getShapeIndex = (shape: ShapeId) => shapes.findIndex((item) => item.id === shape)
-const getColorIndex = (color: ColorId) => colors.findIndex((item) => item.id === color)
+const constraints: Constraint[] = constraintSeeds.map((seed) => {
+  const { row, col, direction } = seed
+  const nextRow = direction === "down" ? row + 1 : row
+  const nextCol = direction === "right" ? col + 1 : col
+  const relation = solutionGrid[row][col] === solutionGrid[nextRow][nextCol] ? "same" : "different"
+  return { row, col, direction, relation }
+})
 
-const makeInitialBoard = () =>
-  targetBoard.map((cell, index) => {
-    const shapeIndex = getShapeIndex(cell.shape)
-    const colorIndex = getColorIndex(cell.color)
-
-    return {
-      shape: shapes[(shapeIndex + 1 + index) % shapes.length].id,
-      color: colors[(colorIndex + 2 + index) % colors.length].id,
-    }
-  })
+const makeInitialBoard = (): CellValue[][] =>
+  Array.from({ length: gridSize }, (_, row) =>
+    Array.from({ length: gridSize }, (_, col) => {
+      if (fixedCells.has(`${row}-${col}`)) {
+        return solutionGrid[row][col]
+      }
+      return null
+    })
+  )
 
 const renderShape = (shape: ShapeId, colorHex: string) => {
   switch (shape) {
-    case "circle":
-      return <circle cx="50" cy="50" r="28" fill={colorHex} />
-    case "square":
-      return <rect x="22" y="22" width="56" height="56" rx="8" fill={colorHex} />
-    case "triangle":
-      return <polygon points="50 16 86 84 14 84" fill={colorHex} />
-    case "diamond":
-      return <polygon points="50 12 88 50 50 88 12 50" fill={colorHex} />
+    case "arc":
+      return (
+        <>
+          <path d="M20 64c0-19.9 16.1-36 36-36 7.5 0 14.6 2.3 20.5 6.3" stroke={colorHex} strokeWidth="12" strokeLinecap="round" fill="none" />
+          <circle cx="62" cy="28" r="10" fill={colorHex} />
+        </>
+      )
+    case "spire":
+      return (
+        <>
+          <path d="M50 12 80 44 62 44 62 88 38 88 38 44 20 44Z" fill={colorHex} />
+          <circle cx="50" cy="34" r="8" fill="#fff" opacity="0.7" />
+        </>
+      )
   }
 }
 
-const ShapeTile = ({ cell, isSelected, isTarget }: { cell: Cell; isSelected: boolean; isTarget: boolean }) => {
-  const color = colors.find((item) => item.id === cell.color) ?? colors[0]
+const ShapeTile = ({
+  value,
+  isFixed,
+  isSelected,
+  isInvalid,
+}: {
+  value: CellValue
+  isFixed: boolean
+  isSelected: boolean
+  isInvalid: boolean
+}) => {
+  const shape = shapes.find((item) => item.id === value)
 
   return (
     <div
       className={`flex items-center justify-center rounded-2xl border transition shadow-sm ${
-        isTarget
-          ? "border-slate-200/70 dark:border-slate-700/70 bg-white/60 dark:bg-slate-900/60"
-          : "border-slate-300/80 dark:border-slate-700/80 bg-white/80 dark:bg-slate-900/80"
-      } ${isSelected ? "ring-2 ring-sky-400/80" : ""}`}
+        isFixed
+          ? "border-slate-300/80 dark:border-slate-600/80 bg-slate-100/90 dark:bg-slate-800/70"
+          : "border-slate-200/80 dark:border-slate-700/80 bg-white/90 dark:bg-slate-900/70"
+      } ${isSelected ? "ring-2 ring-teal-400/80" : ""} ${isInvalid ? "border-rose-400 ring-2 ring-rose-300/70" : ""}`}
     >
-      <svg viewBox="0 0 100 100" className="h-12 w-12">
-        {renderShape(cell.shape, color.hex)}
-      </svg>
+      {shape ? (
+        <svg viewBox="0 0 100 100" className="h-10 w-10 sm:h-11 sm:w-11">
+          {renderShape(shape.id, shape.color)}
+        </svg>
+      ) : (
+        <span className="text-[10px] uppercase tracking-[0.3em] text-slate-300 dark:text-slate-600">•</span>
+      )}
     </div>
   )
 }
 
+const getCellKey = (row: number, col: number) => `${row}-${col}`
+
+const getCellValue = (grid: CellValue[][], row: number, col: number) => grid[row]?.[col] ?? null
+
+const hasTriple = (line: CellValue[]) =>
+  line.some((value, index) => value && value === line[index + 1] && value === line[index + 2])
+
+const isLineOverfilled = (line: CellValue[]) => {
+  const arcCount = line.filter((cell) => cell === "arc").length
+  const spireCount = line.filter((cell) => cell === "spire").length
+  return arcCount > halfRow || spireCount > halfRow
+}
+
+const isLineComplete = (line: CellValue[]) => !line.includes(null)
+
+const isLineBalanced = (line: CellValue[]) => {
+  const arcCount = line.filter((cell) => cell === "arc").length
+  const spireCount = line.filter((cell) => cell === "spire").length
+  return arcCount === halfRow && spireCount === halfRow
+}
+
+const getLineStatus = (line: CellValue[]) => {
+  if (isLineOverfilled(line)) return "over"
+  if (hasTriple(line)) return "triple"
+  if (isLineComplete(line) && !isLineBalanced(line)) return "unbalanced"
+  if (isLineComplete(line) && isLineBalanced(line)) return "balanced"
+  return "progress"
+}
+
 export default function ShapePuzzleGame() {
-  const [board, setBoard] = useState<Cell[]>(() => makeInitialBoard())
+  const [board, setBoard] = useState<CellValue[][]>(() => makeInitialBoard())
   const [moves, setMoves] = useState(0)
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+  const [selectedCell, setSelectedCell] = useState<{ row: number; col: number } | null>(null)
 
   const solved = useMemo(
-    () => board.every((cell, index) => cell.shape === targetBoard[index].shape && cell.color === targetBoard[index].color),
+    () =>
+      board.every((row, rowIndex) =>
+        row.every((cell, colIndex) => cell !== null && cell === solutionGrid[rowIndex][colIndex])
+      ),
     [board]
   )
 
-  const updateCell = (index: number, updater: (cell: Cell) => Cell) => {
-    setBoard((prev) => prev.map((cell, cellIndex) => (cellIndex === index ? updater(cell) : cell)))
+  const lineStatuses = useMemo(() => {
+    const rows = board.map((row) => getLineStatus(row))
+    const cols = Array.from({ length: gridSize }, (_, col) => getLineStatus(board.map((row) => row[col])))
+    return { rows, cols }
+  }, [board])
+
+  const invalidCells = useMemo(() => {
+    const invalid = new Set<string>()
+
+    board.forEach((row, rowIndex) => {
+      if (hasTriple(row) || isLineOverfilled(row)) {
+        row.forEach((_, colIndex) => invalid.add(getCellKey(rowIndex, colIndex)))
+      }
+    })
+
+    for (let col = 0; col < gridSize; col += 1) {
+      const column = board.map((row) => row[col])
+      if (hasTriple(column) || isLineOverfilled(column)) {
+        column.forEach((_, rowIndex) => invalid.add(getCellKey(rowIndex, col)))
+      }
+    }
+
+    constraints.forEach((constraint) => {
+      const first = getCellValue(board, constraint.row, constraint.col)
+      const second = getCellValue(
+        board,
+        constraint.direction === "down" ? constraint.row + 1 : constraint.row,
+        constraint.direction === "right" ? constraint.col + 1 : constraint.col
+      )
+
+      if (first && second) {
+        const matches = first === second
+        const isValid = constraint.relation === "same" ? matches : !matches
+        if (!isValid) {
+          invalid.add(getCellKey(constraint.row, constraint.col))
+          invalid.add(
+            getCellKey(
+              constraint.direction === "down" ? constraint.row + 1 : constraint.row,
+              constraint.direction === "right" ? constraint.col + 1 : constraint.col
+            )
+          )
+        }
+      }
+    })
+
+    return invalid
+  }, [board])
+
+  const updateCell = (row: number, col: number, steps = 1) => {
+    if (fixedCells.has(getCellKey(row, col))) return
+
+    setBoard((prev) => {
+      const next = prev.map((line) => [...line])
+      let current = next[row][col]
+      for (let step = 0; step < steps; step += 1) {
+        if (current === null) {
+          current = shapes[0].id
+        } else if (current === shapes[0].id) {
+          current = shapes[1].id
+        } else {
+          current = null
+        }
+      }
+      next[row][col] = current
+      return next
+    })
     setMoves((prev) => prev + 1)
   }
 
-  const cycleShape = (index: number) => {
-    updateCell(index, (cell) => {
-      const shapeIndex = getShapeIndex(cell.shape)
-      return { ...cell, shape: shapes[(shapeIndex + 1) % shapes.length].id }
-    })
-  }
-
-  const cycleColor = (index: number) => {
-    updateCell(index, (cell) => {
-      const colorIndex = getColorIndex(cell.color)
-      return { ...cell, color: colors[(colorIndex + 1) % colors.length].id }
-    })
-  }
-
-  const handleTileClick = (index: number, event: MouseEvent<HTMLButtonElement>) => {
-    setSelectedIndex(index)
-    if (event.shiftKey) {
-      cycleColor(index)
-      return
-    }
-
-    cycleShape(index)
+  const handleTileClick = (row: number, col: number, event: MouseEvent<HTMLButtonElement>) => {
+    setSelectedCell({ row, col })
+    updateCell(row, col, event.shiftKey ? 2 : 1)
   }
 
   const handleReset = () => {
     setBoard(makeInitialBoard())
     setMoves(0)
-    setSelectedIndex(null)
+    setSelectedCell(null)
   }
 
-  const selectedCell = selectedIndex !== null ? board[selectedIndex] : null
+  const selectedValue = selectedCell ? board[selectedCell.row][selectedCell.col] : null
+  const selectedShape = shapes.find((shape) => shape.id === selectedValue) ?? null
+
+  const cellSize = "clamp(44px, 7vw, 70px)"
+  const cellGap = "clamp(6px, 1.2vw, 12px)"
+  const constraintSize = "clamp(16px, 2vw, 20px)"
 
   return (
     <div className="space-y-8">
       <header className="space-y-3">
         <p className="text-xs font-mono uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Puzzle</p>
         <div className="space-y-2">
-          <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 dark:text-slate-50">Shape Circuit</h1>
+          <h1 className="text-2xl sm:text-3xl font-semibold text-slate-900 dark:text-slate-50">Arc &amp; Spire Tango</h1>
           <p className="text-sm sm:text-base text-slate-600 dark:text-slate-300 max-w-2xl">
-            Align every tile with the target pattern. Click a tile to rotate its shape, or hold Shift while clicking to
-            cycle the color. It&apos;s a medium difficulty logic warm-up.
+            Fill the 8 × 8 grid so each row and column holds four arcs and four spires. No three identical shapes may
+            touch in a row or column. Match the equality and contrast clues to finish the tango.
           </p>
         </div>
       </header>
 
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
         <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Target</h2>
-              <p className="text-xs text-slate-500 dark:text-slate-400">Match this arrangement.</p>
-            </div>
-            <span className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">3 × 3</span>
-          </div>
-          <div className="grid grid-cols-3 gap-3">
-            {targetBoard.map((cell, index) => (
-              <ShapeTile key={`target-${index}`} cell={cell} isSelected={false} isTarget />
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Your Board</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Puzzle Grid</h2>
               <p className="text-xs text-slate-500 dark:text-slate-400">Moves: {moves}</p>
             </div>
             <div className="flex items-center gap-3">
@@ -178,7 +308,7 @@ export default function ShapePuzzleGame() {
                 <button
                   type="button"
                   onClick={handleReset}
-                  className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
+                  className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300 hover:border-teal-400 dark:hover:border-teal-500 transition"
                 >
                   Reset
                 </button>
@@ -191,59 +321,146 @@ export default function ShapePuzzleGame() {
             </div>
           </div>
 
-          <div className="grid grid-cols-3 gap-3">
-            {board.map((cell, index) => (
-              <button
-                key={`play-${index}`}
-                type="button"
-                onClick={(event) => handleTileClick(index, event)}
-                className={`focus:outline-none transition ${
-                  solved ? "animate-[pulse_1.6s_ease-in-out_infinite]" : ""
-                }`}
-                aria-pressed={selectedIndex === index}
-                aria-label={`Tile ${index + 1}: ${shapes.find((item) => item.id === cell.shape)?.label}, ${colors.find((item) => item.id === cell.color)?.label}`}
-              >
-                <ShapeTile cell={cell} isSelected={selectedIndex === index} isTarget={false} />
-              </button>
-            ))}
+          <div className="relative w-fit">
+            <div
+              className="grid"
+              style={{
+                gridTemplateColumns: `repeat(${gridSize}, ${cellSize})`,
+                gap: cellGap,
+                ["--cell-size" as string]: cellSize,
+                ["--cell-gap" as string]: cellGap,
+                ["--constraint-size" as string]: constraintSize,
+              }}
+            >
+              {board.map((row, rowIndex) =>
+                row.map((cell, colIndex) => {
+                  const isFixed = fixedCells.has(getCellKey(rowIndex, colIndex))
+                  const isSelected =
+                    selectedCell?.row === rowIndex && selectedCell?.col === colIndex
+                  const isInvalid = invalidCells.has(getCellKey(rowIndex, colIndex))
+                  return (
+                    <button
+                      key={`cell-${rowIndex}-${colIndex}`}
+                      type="button"
+                      onClick={(event) => handleTileClick(rowIndex, colIndex, event)}
+                      className={`focus:outline-none transition ${
+                        solved ? "animate-[pulse_1.6s_ease-in-out_infinite]" : ""
+                      }`}
+                      aria-pressed={isSelected}
+                      aria-label={`Row ${rowIndex + 1}, Column ${colIndex + 1}: ${
+                        cell ? shapes.find((shape) => shape.id === cell)?.label : "empty"
+                      }`}
+                    >
+                      <ShapeTile value={cell} isFixed={isFixed} isSelected={isSelected} isInvalid={isInvalid} />
+                    </button>
+                  )
+                })
+              )}
+            </div>
+            {constraints.map((constraint) => {
+              const left =
+                constraint.direction === "right"
+                  ? `calc((var(--cell-size) + var(--cell-gap)) * ${constraint.col} + var(--cell-size) + var(--cell-gap) / 2 - var(--constraint-size) / 2)`
+                  : `calc((var(--cell-size) + var(--cell-gap)) * ${constraint.col} + var(--cell-size) / 2 - var(--constraint-size) / 2)`
+              const top =
+                constraint.direction === "down"
+                  ? `calc((var(--cell-size) + var(--cell-gap)) * ${constraint.row} + var(--cell-size) + var(--cell-gap) / 2 - var(--constraint-size) / 2)`
+                  : `calc((var(--cell-size) + var(--cell-gap)) * ${constraint.row} + var(--cell-size) / 2 - var(--constraint-size) / 2)`
+              return (
+                <div
+                  key={`constraint-${constraint.row}-${constraint.col}-${constraint.direction}`}
+                  className={`absolute flex items-center justify-center rounded-full border border-slate-200/80 dark:border-slate-700/80 bg-white/90 dark:bg-slate-900/80 text-xs font-semibold shadow-sm ${
+                    constraint.relation === "same" ? "text-teal-500" : "text-orange-500"
+                  }`}
+                  style={{
+                    width: "var(--constraint-size)",
+                    height: "var(--constraint-size)",
+                    left,
+                    top,
+                  }}
+                >
+                  {constraint.relation === "same" ? "=" : "×"}
+                </div>
+              )
+            })}
           </div>
+        </section>
 
-          <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-slate-50/80 dark:bg-slate-900/60 p-4 space-y-3">
+        <section className="space-y-4">
+          <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/70 p-4 space-y-3">
             <p className="text-xs uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Selected tile</p>
             {selectedCell ? (
-              <div className="flex flex-wrap items-center gap-3">
-                <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
-                  {shapes.find((item) => item.id === selectedCell.shape)?.label}
-                </span>
-                <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
-                  {colors.find((item) => item.id === selectedCell.color)?.label}
-                </span>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => selectedIndex !== null && cycleShape(selectedIndex)}
-                    className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
-                  >
-                    Next shape
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => selectedIndex !== null && cycleColor(selectedIndex)}
-                    className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:border-sky-400 dark:hover:border-sky-500 transition"
-                  >
-                    Next color
-                  </button>
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                    Row {selectedCell.row + 1}, Column {selectedCell.col + 1}
+                  </span>
+                  <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                    {selectedShape ? selectedShape.label : "Empty"}
+                  </span>
+                  {fixedCells.has(getCellKey(selectedCell.row, selectedCell.col)) && (
+                    <span className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      Locked
+                    </span>
+                  )}
                 </div>
+                {!fixedCells.has(getCellKey(selectedCell.row, selectedCell.col)) && (
+                  <button
+                    type="button"
+                    onClick={() => updateCell(selectedCell.row, selectedCell.col)}
+                    className="rounded-full border border-slate-200/80 dark:border-slate-700/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:border-teal-400 dark:hover:border-teal-500 transition"
+                  >
+                    Cycle shape
+                  </button>
+                )}
               </div>
             ) : (
               <p className="text-sm text-slate-600 dark:text-slate-300">Select a tile to reveal controls.</p>
             )}
           </div>
 
+          <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-slate-50/80 dark:bg-slate-900/60 p-4 space-y-3">
+            <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Row &amp; column balance</h3>
+            <div className="grid grid-cols-2 gap-2 text-xs text-slate-600 dark:text-slate-300">
+              {lineStatuses.rows.map((status, index) => (
+                <div key={`row-${index}`} className="flex items-center justify-between">
+                  <span>Row {index + 1}</span>
+                  <span
+                    className={`font-semibold ${
+                      status === "balanced"
+                        ? "text-emerald-600 dark:text-emerald-300"
+                        : status === "progress"
+                          ? "text-slate-500 dark:text-slate-400"
+                          : "text-rose-500 dark:text-rose-300"
+                    }`}
+                  >
+                    {status === "balanced" ? "Balanced" : status === "progress" ? "Filling" : "Check"}
+                  </span>
+                </div>
+              ))}
+              {lineStatuses.cols.map((status, index) => (
+                <div key={`col-${index}`} className="flex items-center justify-between">
+                  <span>Col {index + 1}</span>
+                  <span
+                    className={`font-semibold ${
+                      status === "balanced"
+                        ? "text-emerald-600 dark:text-emerald-300"
+                        : status === "progress"
+                          ? "text-slate-500 dark:text-slate-400"
+                          : "text-rose-500 dark:text-rose-300"
+                    }`}
+                  >
+                    {status === "balanced" ? "Balanced" : status === "progress" ? "Filling" : "Check"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
           {solved && (
             <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/30 dark:bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-200">
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="font-semibold">🎉 Circuit aligned! Puzzle complete.</div>
+                <div className="font-semibold">🎉 Tango complete! Every clue matches.</div>
                 <button
                   type="button"
                   onClick={handleReset}
@@ -261,13 +478,14 @@ export default function ShapePuzzleGame() {
         <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/70 dark:bg-slate-900/70 p-4">
           <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">How it works</h3>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-            Every tile has a shape and a color. Cycle them until your board mirrors the target grid exactly.
+            Tap a tile to cycle between arc, spire, and empty. The equality symbol means the adjacent shapes match, while
+            the contrast symbol means they differ.
           </p>
         </div>
         <div className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/70 dark:bg-slate-900/70 p-4">
           <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Keyboard tip</h3>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-            Use Shift + click to change a tile&apos;s color without cycling its shape.
+            Use Shift + click to advance two steps in the cycle for faster edits.
           </p>
         </div>
       </section>


### PR DESCRIPTION
### Motivation

- Replace the existing small shape-matching puzzle with an 8×8 tango-style grid that mirrors the requested arc/spire aesthetic and gameplay constraints. 
- Provide fixed clue cells and pairwise equality/contrast clues so the puzzle plays like a typical "tango" logic puzzle.

### Description

- Reworked `app/games/shape-puzzle/ShapePuzzleGame.tsx` to implement an 8×8 grid using two shapes (`arc` and `spire`), with an internal `solutionGrid`, a set of `fixedCells`, and visual constraint markers rendered between adjacent cells. 
- Added rule validation and UI feedback for row/column balance (four of each shape per line), three-in-a-row detection, and constraint (same/different) violations, exposing per-line status and invalid-cell highlighting. 
- Updated interactions and copy: tiles cycle through `arc → spire → empty`, `Shift+click` advances two steps, move counter, selection panel, and finished/Reset UI.

### Testing

- Ran `pnpm build`, which reported failure to download Google Fonts in this environment and therefore could not complete font download (build environment fell back to local fonts); the font fetch issue is environmental and unrelated to the code changes. 
- Started the dev server with `pnpm dev` and used an automated Playwright script to load `/games/shape-puzzle` and capture a screenshot, which succeeded and returned HTTP 200 for the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d15f093d48332a2201ee19718acff)