### PR TITLE
Fix blog post metadata wrapping on mobile

### DIFF
--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -82,11 +82,11 @@ export default async function PostPage(props: {
         </p>
       )}
       <div className="flex flex-col gap-4 mb-8">
-        <div className="flex items-center gap-4 text-gray-500 dark:text-gray-400">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-500 dark:text-gray-400">
           <time>{date}</time>
-          <div className="w-px h-4 bg-gray-200 dark:bg-gray-700" />
+          <div className="hidden sm:block w-px h-4 bg-gray-200 dark:bg-gray-700" />
           <span>{readingTime}</span>
-          <div className="w-px h-4 bg-gray-200 dark:bg-gray-700" />
+          <div className="hidden sm:block w-px h-4 bg-gray-200 dark:bg-gray-700" />
           {post.tags && <TagList tags={post.tags} />}
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Blog post header metadata (date, reading time, tags) could overflow on small viewports because the metadata row did not wrap and separators forced a single-line layout.

### Description
- Allow the metadata row to wrap on small screens by adding `flex-wrap` and separate horizontal/vertical gaps with `gap-x-4 gap-y-2` and set a compact `text-sm` style.
- Hide the thin vertical separator elements on small viewports by changing them to `hidden sm:block` so they don't cause layout overflow.

### Testing
- Started the dev server with `pnpm exec next dev` and confirmed the post page renders (server started successfully). 
- Captured a mobile viewport screenshot via a Playwright script which shows the metadata row wrapping as intended (succeeded). 
- Ran `pnpm build`, which failed in this environment due to inability to fetch Google Fonts during the build (font download error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986903a17e08332bb941ea482b4a899)