### PR TITLE
Improve mobile-friendly blog content layout

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -59,7 +59,7 @@ export default async function PagePage(props: {
   const mdxSource = await processMdx(page.body.raw)
 
   return (
-    <article className="py-6 prose dark:prose-invert">
+    <article className="py-6 prose prose-sm sm:prose-base dark:prose-invert break-words">
       <h1 className="mb-2 text-purple-700 dark:text-purple-300">{page.title}</h1>
       {page.description && <p className="text-xl">{page.description}</p>}
       <Mdx code={mdxSource} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -122,7 +122,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <ScrollToTop />
-          <div className="relative isolate min-h-screen overflow-hidden lg:overflow-visible bg-slate-100 dark:bg-slate-950 selection:bg-lime-200 selection:text-slate-900 dark:selection:bg-emerald-400/30">
+          <div className="relative isolate min-h-screen overflow-x-hidden lg:overflow-visible bg-slate-100 dark:bg-slate-950 selection:bg-lime-200 selection:text-slate-900 dark:selection:bg-emerald-400/30">
             <div className="pointer-events-none absolute inset-0">
               <div className="absolute inset-0 opacity-65 mix-blend-soft-light bg-[radial-gradient(circle_at_20%_20%,rgba(99,102,241,0.18),transparent_42%),radial-gradient(circle_at_82%_12%,rgba(16,185,129,0.18),transparent_34%),radial-gradient(circle_at_60%_82%,rgba(14,165,233,0.16),transparent_36%)]" />
               <div className="absolute inset-0 opacity-60 bg-[linear-gradient(rgba(148,163,184,0.16)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.16)_1px,transparent_1px)] bg-[size:160px_160px]" />
@@ -167,7 +167,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                   </div>
                 </aside>
 
-                <div className="space-y-6">
+                <div className="space-y-6 min-w-0">
                   <div className="rounded-[28px] border border-slate-200/80 dark:border-slate-800/80 bg-white/70 dark:bg-slate-900/70 backdrop-blur-xl shadow-[0_20px_90px_rgba(15,23,42,0.25)]">
                     <div className="relative overflow-hidden rounded-[28px] border border-slate-100/80 dark:border-slate-800/80">
                       <div className="absolute -inset-x-10 -top-10 h-40 bg-gradient-to-br from-sky-200/50 via-transparent to-purple-200/40 dark:from-sky-500/15 dark:via-transparent dark:to-purple-500/15 blur-3xl" />

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -74,7 +74,7 @@ export default async function PostPage(props: {
   const mdxSource = await processMdx(post.body.raw)
 
   return (
-    <article className="prose dark:prose-invert max-w-none pb-6">
+    <article className="prose prose-sm sm:prose-base dark:prose-invert max-w-none pb-6 break-words">
       <h1 className="mb-2 text-purple-700 dark:text-purple-300">{post.title}</h1>
       {post.description && (
         <p className="text-xl mt-0 text-slate-700 dark:text-slate-200">

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -28,13 +28,14 @@ const components = {
       const imageSrc = src.startsWith('/') ? src : `/${src}`;
       
       return (
-        <div className="my-6 overflow-hidden rounded-lg">
+        <div className="my-6 overflow-hidden rounded-lg max-w-full">
           <Image
             src={imageSrc}
             alt={alt || ""}
             width={800}
             height={500}
-            className="w-full h-auto"
+            sizes="(max-width: 768px) 100vw, 800px"
+            className="w-full h-auto max-w-full"
             style={{ maxWidth: '100%', height: 'auto' }}
             {...restImgProps}
           />
@@ -121,12 +122,23 @@ const components = {
         alt={alt || ""}
         width={800}
         height={500}
-        className="w-full h-auto my-6 rounded-lg"
+        sizes="(max-width: 768px) 100vw, 800px"
+        className="w-full h-auto max-w-full my-6 rounded-lg"
         style={{ maxWidth: '100%', height: 'auto' }}
         {...props}
       />
     );
   },
+  video: ({ children, ...props }: any) => (
+    <video className="w-full h-auto max-w-full my-6 rounded-lg" controls {...props}>
+      {children}
+    </video>
+  ),
+  iframe: ({ ...props }: any) => (
+    <div className="my-6 w-full max-w-full overflow-hidden rounded-lg">
+      <iframe className="w-full max-w-full aspect-video" {...props} />
+    </div>
+  ),
   code: ({ className, children, ...props }: any) => {
     const match = /language-(\w+)/.exec(className || '');
     return match ? (
@@ -176,7 +188,7 @@ export function Mdx({ code }: MdxProps) {
   try {
     // Render the MDX content
     return (
-      <div className="mdx-content">
+      <div className="mdx-content min-w-0 break-words">
         <MDXRemote {...code} components={components} />
       </div>
     );


### PR DESCRIPTION
### Motivation
- Mobile readers experienced oversized images and embedded media, clipped text, and horizontal scrolling on blog posts.
- The change aims to ensure text and media scale to device widths and avoid horizontal overflow or zooming on small screens.

### Description
- Prevent horizontal clipping by changing the root content wrapper to `overflow-x-hidden` and making the main content column shrinkable with `min-w-0` in `app/layout.tsx`.
- Reduce article typography on small screens and enable long-word wrapping by adding `prose-sm sm:prose-base` and `break-words` to `app/posts/[...slug]/page.tsx` and `app/[...slug]/page.tsx`.
- Make MDX media responsive in `components/mdx-components.tsx` by adding `sizes="(max-width: 768px) 100vw, 800px"`, `max-w-full`, and `max-w-full` wrappers for images, and adding responsive handlers for `video` and `iframe` elements.
- Add container safeguards for MDX content (`min-w-0 break-words`) to avoid overflow from long content or embedded elements.

### Testing
- Attempted `pnpm build`, which ran but failed to complete due to being unable to fetch Google Fonts in this environment (network/font fetch error).
- Started the development server with `pnpm dev` and confirmed the app became ready locally.
- Ran a Playwright script against a mobile viewport and produced a screenshot of a blog post to visually verify the responsive layout (artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873a8d22e88332907c97e32e61555e)